### PR TITLE
Allow reuse of existing aliases with :jvm-opts

### DIFF
--- a/components/external-test-runner/src/org/corfield/external_test_runner/core.clj
+++ b/components/external-test-runner/src/org/corfield/external_test_runner/core.clj
@@ -94,8 +94,9 @@
   options for that k, resolving recursively if needed, or nil."
   [aliases k]
   (let [opts-coll (get aliases k)]
-    (when (seq opts-coll)
-      (into [] (mapcat #(if (string? %) [%] (chase-opts-key aliases %))) opts-coll))))
+    (or (:jvm-opts opts-coll)
+        (when (seq opts-coll)
+          (into [] (mapcat #(if (string? %) [%] (chase-opts-key aliases %))) opts-coll)))))
 
 (comment
   (let [options {:include-src-dir true}]


### PR DESCRIPTION
This implements the change suggested in  #11

I tested manually with a few different configurations and it seems to work fine. I didn't find tests in the project so I didn't add one either, but I guess it would have to be some sort of integration test.

I will have a look at the documentation tomorrow morning.

