### PR TITLE
Add dialect support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+* v0.7.0 in progress
+  * Switch from `bricks-to-test` to `bricks-to-test-all-sources` in Polylith 0.2.22.
+  * Drop support for WS v2.0 (`changes` data moved to `project` in v3.0).
+
 v0.6.1 d0f51c2 -- 2024-12-02
 * Fix [#11](https://github.com/seancorfield/polylith-external-test-runner/issues/11) by supporting `:jvm-opts` in `poly test` property handling.
 * Address [#8](https://github.com/seancorfield/polylith-external-test-runner/issues/8) by noting that the standalone `poly` tool cannot be used with external test runners.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ dependency.
 ## Usage
 
 Ensure you are using a recent version Polylith that supports
-external test runners (v0.2.17-alpha or later).
+external test runners (v0.2.22-SNAPSHOT #2 or later).
 
 You must be using a `:poly` alias in your `deps.edn` file to run the Polylith
 tool and tests, since you need to be able to modify the classpath to add an
@@ -20,7 +20,8 @@ make this test-runner available:
 
 ```clojure
 io.github.seancorfield/polylith-external-test-runner
-{:git/tag "v0.6.1" :git/sha "d0f51c2"
+{;:git/tag "v0.6.1" :git/sha "d0f51c2" -- supports Polylith 0.2.18 and later
+ :git/sha ""
  :deps/root "projects/runner"}
 ```
 

--- a/components/external-test-runner/src/org/corfield/external_test_runner/core.clj
+++ b/components/external-test-runner/src/org/corfield/external_test_runner/core.clj
@@ -10,6 +10,10 @@
   (:import (java.lang ProcessBuilder ProcessBuilder$Redirect)
            (java.util List)))
 
+ (defn- clj-namespace? [{:keys [file-path]}]
+  (or (str/ends-with? file-path ".clj")
+      (str/ends-with? file-path ".cljc")))
+
 (defn brick-test-namespaces [options bricks test-brick-names]
   (let [nses-fn (fn [selectors]
                   (juxt :name
@@ -23,6 +27,7 @@
         (into {} (map (nses-fn selectors)) bricks)]
     (into []
           (comp (mapcat brick-name->namespaces)
+                (filter clj-namespace?)
                 (map :namespace))
           test-brick-names)))
 

--- a/components/external-test-runner/test/org/corfield/external_test_runner/ignored_test.cljs
+++ b/components/external-test-runner/test/org/corfield/external_test_runner/ignored_test.cljs
@@ -1,0 +1,7 @@
+(ns org.corfield.external-test-runner.ignored-test
+  (:require [clojure.test :refer [deftest is]]
+            [org.corfield.external-test-runner.core]))
+
+(deftest dummy-test
+  ;; I should not run because I'm ClojureScript
+  (is (= 1 0)))

--- a/components/external-test-runner/test/org/corfield/external_test_runner/interface_test.cljc
+++ b/components/external-test-runner/test/org/corfield/external_test_runner/interface_test.cljc
@@ -3,4 +3,5 @@
             [org.corfield.external-test-runner.interface]))
 
 (deftest ^:dev dummy-test
+  ;; I should run because I'm .cljc
   (is (= 1 1)))

--- a/deps.edn
+++ b/deps.edn
@@ -5,11 +5,17 @@
                      polylith-external-test-runner.components/util {:local/root "components/util"}
                      org.clojure/clojure {:mvn/version "1.11.4"}}}
   :test {:extra-paths []
-         :extra-deps {polylith/clj-poly {:mvn/version "0.2.21"}}}
+         :extra-deps {polylith/clj-poly #_{:mvn/version "0.2.21"}
+                      {:git/url   "https://github.com/polyfy/polylith.git"
+                       :sha       "6ca059f206e7771c5b0173622673df9ef76d25ec"
+                       :deps/root "projects/poly"}}}
   :example-opts [:sub-opts "-Dexample=opts" :nested-opts]
   :sub-opts ["-Dsub.example=more.opts"]
   :nested-opts {:jvm-opts ["-Dnested.example=even.more.opts"]}
-  :poly {:extra-deps {polylith/clj-poly {:mvn/version "0.2.21"}
+  :poly {:extra-deps {polylith/clj-poly #_{:mvn/version "0.2.21"}
+                      {:git/url   "https://github.com/polyfy/polylith.git"
+                       :sha       "6ca059f206e7771c5b0173622673df9ef76d25ec"
+                       :deps/root "projects/poly"}
                       io.github.seancorfield/polylith-external-test-runner
                       {:local/root "projects/runner"}}
          :jvm-opts ["-Dpoly.test.jvm.opts=:example-opts"]

--- a/deps.edn
+++ b/deps.edn
@@ -5,16 +5,18 @@
                      polylith-external-test-runner.components/util {:local/root "components/util"}
                      org.clojure/clojure {:mvn/version "1.11.4"}}}
   :test {:extra-paths []
-         :extra-deps {polylith/clj-poly #_{:mvn/version "0.2.21"}
+         :extra-deps {polylith/clj-poly {:mvn/version "0.2.22-SNAPSHOT"}
+                      #_
                       {:git/url   "https://github.com/polyfy/polylith.git"
-                       :sha       "6ca059f206e7771c5b0173622673df9ef76d25ec"
+                       :sha       "345af4992b5ec97b712cd5b1a2a06f731cdfd61d"
                        :deps/root "projects/poly"}}}
   :example-opts [:sub-opts "-Dexample=opts" :nested-opts]
   :sub-opts ["-Dsub.example=more.opts"]
   :nested-opts {:jvm-opts ["-Dnested.example=even.more.opts"]}
-  :poly {:extra-deps {polylith/clj-poly #_{:mvn/version "0.2.21"}
+  :poly {:extra-deps {polylith/clj-poly {:mvn/version "0.2.22-SNAPSHOT"}
+                      #_
                       {:git/url   "https://github.com/polyfy/polylith.git"
-                       :sha       "6ca059f206e7771c5b0173622673df9ef76d25ec"
+                       :sha       "345af4992b5ec97b712cd5b1a2a06f731cdfd61d"
                        :deps/root "projects/poly"}
                       io.github.seancorfield/polylith-external-test-runner
                       {:local/root "projects/runner"}}

--- a/workspace.edn
+++ b/workspace.edn
@@ -2,6 +2,7 @@
        :auto-add false}
  :top-namespace "org.corfield"
  :interface-ns "interface"
+ :dialects #{"clj" "cljs"}
  :default-profile-name "default"
  :compact-views #{}
  :tag-patterns {:stable "stable-*"


### PR DESCRIPTION
See https://github.com/polyfy/polylith/discussions/525

This PR depends on the core PR mentioned in that 
discussion and adds filtering on dialects so only
`.clj` and `.cljc` files are loaded for testing.

Signed-off-by: Sean Corfield <sean@corfield.org>