### PR TITLE
Add POLY_TEST_SHARD for parallel CI test execution

### DIFF
--- a/components/external-test-runner/src/org/corfield/external_test_runner/core.clj
+++ b/components/external-test-runner/src/org/corfield/external_test_runner/core.clj
@@ -21,6 +21,31 @@
    (or (str/ends-with? file-path ".cljs")
        (str/ends-with? file-path ".cljc")))
 
+(defn parse-test-shard
+  "Parse a shard spec string like \"2/4\" into [shard-index shard-count].
+  Returns nil if the string is nil or not a valid shard spec.
+  shard-index is 1-based."
+  [s]
+  (when (and s (re-matches #"\d+/\d+" s))
+    (let [[idx cnt] (str/split s #"/")
+          idx (parse-long idx)
+          cnt (parse-long cnt)]
+      (when (and (pos? cnt) (<= 1 idx cnt))
+        [idx cnt]))))
+
+(defn shard-namespaces
+  "Given a sequence of namespace strings and a shard spec [index count],
+  return only the namespaces belonging to that shard.
+  Namespaces are sorted alphabetically for deterministic sharding,
+  then distributed round-robin across shards."
+  [nses [shard-index shard-count]]
+  (let [sorted (vec (sort nses))]
+    (into []
+          (comp (map-indexed vector)
+                (filter (fn [[i _]] (= (mod i shard-count) (dec shard-index))))
+                (map second))
+          sorted)))
+
 (defn brick-test-namespaces [test-opts by-ext bricks test-brick-names]
   (let [nses-fn (fn [selectors]
                   (juxt :name
@@ -330,16 +355,20 @@
 
         ;; TODO: if the project tests aren't to be run, we might further narrow this down
         test-sources-present (-> paths :test seq)
-        test-nses*     (->> [(brick-test-namespaces test-opts clj-namespace? (into components bases) bricks-to-test)
-                             (project-test-namespaces test-opts clj-namespace? project-name projects-to-test namespaces)]
-                            (into [] cat)
-                            (delay))
+        shard-spec   (parse-test-shard (System/getenv "POLY_TEST_SHARD"))
+        _            (when shard-spec
+                       (println (str "Test sharding: running shard " (first shard-spec)
+                                     " of " (second shard-spec))))
+        test-nses*     (delay
+                        (cond-> (into [] cat [(brick-test-namespaces test-opts clj-namespace? (into components bases) bricks-to-test)
+                                              (project-test-namespaces test-opts clj-namespace? project-name projects-to-test namespaces)])
+                          shard-spec (shard-namespaces shard-spec)))
         shadow*        (delay (when shadow?
                                 (read-shadow-cljs project-name projects-to-test project-dir)))
-        test-cljs*     (->> [(brick-test-namespaces test-opts cljs-namespace? (into components bases) bricks-to-test)
-                             (project-test-namespaces test-opts cljs-namespace? project-name projects-to-test namespaces)]
-                            (into [] cat)
-                            (delay))
+        test-cljs*     (delay
+                        (cond-> (into [] cat [(brick-test-namespaces test-opts cljs-namespace? (into components bases) bricks-to-test)
+                                              (project-test-namespaces test-opts cljs-namespace? project-name projects-to-test namespaces)])
+                          shard-spec (shard-namespaces shard-spec)))
         java-opts      (or (System/getenv "POLY_TEST_JVM_OPTS")
                            (System/getProperty "poly.test.jvm.opts"))
         opt-key        (when (and java-opts (re-find #"^:[-a-zA-Z0-9]+$" java-opts))

--- a/components/external-test-runner/test/org/corfield/external_test_runner/core_test.clj
+++ b/components/external-test-runner/test/org/corfield/external_test_runner/core_test.clj
@@ -55,3 +55,69 @@
           result (core/merge-shadow-defaults shadow)]
       (is (= {:output-dir "out"} (:build-defaults result)))
       (is (= {:node-test {:autorun true}} (:target-defaults result))))))
+
+(deftest parse-test-shard-test
+  (testing "valid shard specs"
+    (is (= [1 4] (core/parse-test-shard "1/4")))
+    (is (= [2 4] (core/parse-test-shard "2/4")))
+    (is (= [4 4] (core/parse-test-shard "4/4")))
+    (is (= [1 1] (core/parse-test-shard "1/1"))))
+
+  (testing "invalid shard specs return nil"
+    (is (nil? (core/parse-test-shard nil)))
+    (is (nil? (core/parse-test-shard "")))
+    (is (nil? (core/parse-test-shard "abc")))
+    (is (nil? (core/parse-test-shard "0/4")))
+    (is (nil? (core/parse-test-shard "5/4")))
+    (is (nil? (core/parse-test-shard "1/0")))))
+
+(deftest shard-namespaces-test
+  (testing "splits namespaces across shards round-robin"
+    (let [nses ["d.ns" "b.ns" "a.ns" "c.ns" "e.ns" "f.ns"]]
+      ;; sorted: ["a.ns" "b.ns" "c.ns" "d.ns" "e.ns" "f.ns"]
+      ;; shard 1/3: indices 0, 3 -> ["a.ns" "d.ns"]
+      ;; shard 2/3: indices 1, 4 -> ["b.ns" "e.ns"]
+      ;; shard 3/3: indices 2, 5 -> ["c.ns" "f.ns"]
+      (is (= ["a.ns" "d.ns"] (core/shard-namespaces nses [1 3])))
+      (is (= ["b.ns" "e.ns"] (core/shard-namespaces nses [2 3])))
+      (is (= ["c.ns" "f.ns"] (core/shard-namespaces nses [3 3])))))
+
+  (testing "all shards together cover all namespaces"
+    (let [nses ["ns1" "ns2" "ns3" "ns4" "ns5"]
+          all-sharded (into [] cat [(core/shard-namespaces nses [1 3])
+                                    (core/shard-namespaces nses [2 3])
+                                    (core/shard-namespaces nses [3 3])])]
+      (is (= (sort nses) (sort all-sharded)))))
+
+  (testing "single shard returns all namespaces sorted"
+    (let [nses ["c" "a" "b"]]
+      (is (= ["a" "b" "c"] (core/shard-namespaces nses [1 1])))))
+
+  (testing "empty namespaces"
+    (is (= [] (core/shard-namespaces [] [1 3]))))
+
+  (testing "fewer namespaces than shards"
+    (let [nses ["a" "b"]]
+      (is (= ["a"] (core/shard-namespaces nses [1 3])))
+      (is (= ["b"] (core/shard-namespaces nses [2 3])))
+      (is (= []    (core/shard-namespaces nses [3 3]))))))
+
+(deftest shard-integration-test
+  (let [make-nses (fn [shard-spec]
+                    (delay
+                      (cond-> (into [] cat [["c.ns" "a.ns"] ["b.ns" "d.ns" "e.ns"]])
+                        shard-spec (core/shard-namespaces shard-spec))))]
+
+    (testing "sharding with delay+cond-> matches create function pattern"
+      (is (= ["a.ns" "d.ns"] @(make-nses [1 3])))
+      (is (= ["b.ns" "e.ns"] @(make-nses [2 3])))
+      (is (= ["c.ns"]        @(make-nses [3 3]))))
+
+    (testing "nil shard-spec preserves original order (no sharding)"
+      (is (= ["c.ns" "a.ns" "b.ns" "d.ns" "e.ns"] @(make-nses nil))))
+
+    (testing "all shards cover all namespaces"
+      (is (= (sort ["c.ns" "a.ns" "b.ns" "d.ns" "e.ns"])
+             (sort (concat @(make-nses [1 3])
+                           @(make-nses [2 3])
+                           @(make-nses [3 3]))))))))


### PR DESCRIPTION
I added support for splitting test namespaces across CI jobs via a
POLY_TEST_SHARD env var (e.g., POLY_TEST_SHARD=2/4 runs the 2nd of 4 shards).

Namespaces are sorted and distributed round-robin so each shard is
deterministic. It applies to both CLJ and CLJS tests independently,
and when the env var isn't set everything works as before.

I also added tests for the parsing and sharding logic.